### PR TITLE
docs: clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,41 @@
-<!--
----
-page_type: sample
-languages:
-- azdeveloper
-- python
-- bicep
-- html
-products:
-- azure
-- azure-functions
-- azure-pipelines
-- azure-openai
-- azure-cognitive-search
-- ai-services
-- blob-storage
-- table-storage
-urlFragment: function-python-ai-openai-chatgpt
-name: Azure Functions - Chat using Azure OpenAI (Python Function)
-description: This sample shows simple ways to interact with Azure OpenAI & GPT-4 model to build an interactive using Azure Functions using [Azure Open AI Triggers and Bindings extension](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-openai?tabs=isolated-process&pivots=programming-language-python).  You can issue simple prompts and receive completions using the `ask` function, and you can send messages and perform a stateful session with a friendly ChatBot using the `chat` function.
----
--->
-<!-- YAML front-matter schema: https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main#supported-metadata-fields-for-readmemd -->
-
 # Azure Functions
 ## Chat using Azure OpenAI (Python v2 Function) + MCP Orchestration
 
-This sample shows simple ways to interact with Azure OpenAI & GPT-4 model to build an interactive app using Azure Functions and the [Azure Open AI Triggers and Bindings extension](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-openai?tabs=isolated-process&pivots=programming-language-javascript). You can issue simple prompts and receive completions using the `ask` function, send messages and perform a stateful session with a friendly ChatBot using the `chats` functions, and orchestrate tools via Model Context Protocol (MCP) with the new `mcp-*` endpoints.
-
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Azure-Samples/function-python-ai-openai-chatgpt)
+This project demonstrates how to build a Python Azure Functions app that interacts with Azure OpenAI and orchestrates tools via the Model Context Protocol (MCP). It includes a simple `/api/ask` endpoint, several `/api/mcp-*` endpoints for tool execution, and optional chat endpoints backed by assistant bindings.
 
 ## Run on your local environment
 
-### Pre-reqs
-1) [Python 3.8+](https://www.python.org/) 
-2) [Azure Functions Core Tools 4.0.6610 or higher](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Cmacos%2Ccsharp%2Cportal%2Cbash#install-the-azure-functions-core-tools)
-3) [Azurite](https://github.com/Azure/Azurite)
+### Pre-requisites
+1. [Python 3.8+](https://www.python.org/)
+2. [Azure Functions Core Tools 4.0.6610 or higher](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Cmacos%2Ccsharp%2Cportal%2Cbash#install-the-azure-functions-core-tools)
+3. [Azurite](https://github.com/Azure/Azurite) for local storage emulation
 
-The easiest way to install Azurite is using a Docker container or the support built into Visual Studio:
+The easiest way to install Azurite is using a Docker container:
+
 ```bash
 docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite
 ```
 
-4) Once you have your Azure subscription, run the following in a new terminal window to create Azure OpenAI and other resources needed:
+### Provision Azure resources
+
 ```bash
 azd provision
 ```
 
-Take note of the value of `AZURE_OPENAI_ENDPOINT` which can be found in `./.azure/<env name from azd provision>/.env`.  It will look something like:
-```bash
-AZURE_OPENAI_ENDPOINT="https://cog-<unique string>.openai.azure.com/"
-```
+This creates the Azure resources including an Azure OpenAI instance.  The `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_KEY` values can be found in `./.azure/<env-name>/.env`.
 
-Alternatively you can [create an OpenAI resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesTextAnalytics) in the Azure portal to get your key and endpoint. After it deploys, click Go to resource and view the Endpoint value.  You will also need to deploy a model, e.g. with name `chat` and model `gpt-4o`.
+### Local settings
 
-5) Add this `local.settings.json` file to the root of the repo folder to simplify local development. Replace `AZURE_OPENAI_ENDPOINT` with your value from step 4. Optionally you can choose a different model deployment in `CHAT_MODEL_DEPLOYMENT_NAME`. This file will be gitignored to protect secrets from committing to your repo, however by default the sample uses Entra identity (user identity and managed identity) so it is secretless.
+Create a `local.settings.json` file in the repository root.  Replace `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_KEY` with your values.
+
 ```json
 {
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "python",
-    "AZURE_OPENAI_ENDPOINT": "https://cog-<unique string>.openai.azure.com/",
+    "AZURE_OPENAI_ENDPOINT": "https://cog-<unique>.openai.azure.com/",
+    "AZURE_OPENAI_KEY": "<your-key>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "chat",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
@@ -68,227 +43,49 @@ Alternatively you can [create an OpenAI resource](https://portal.azure.com/#crea
 }
 ```
 
-If you plan to use the MCP endpoints, configure the following environment variables as needed (locally you can add them under `Values` in `local.settings.json`):
+### MCP configuration
 
-- `TOOLS_SSE_URL`: The SSE endpoint of your MCP Function server (for example, another Functions app exposing MCP tools). If not set, the service will also check `LOCAL_MCP_SSE_URL` or `MCP_SSE_URL`.
-- `TOOLS_FUNCTIONS_KEY`: Optional Functions key for the remote MCP function; used as `x-functions-key` header. The service will also check `LOCAL_MCP_FUNCTIONS_KEY` or `MCP_SSE_KEY`.
-- `ALLOW_CLIENT_MCP_OVERRIDE`: Set to `true` to allow callers to override `mcp_url` and `mcp_headers` per request for testing.
-- `AZURE_OPENAI_MODEL`: Default model to use for `mcp-*` endpoints, if not provided by the caller.
-- `DEFAULT_REASONING_EFFORT`: One of `low`, `medium`, `high`.
-- `ALLOWED_CORS_ORIGINS`: Comma-separated list of origins to allow for CORS on MCP HTTP endpoints.
+If you plan to use the MCP endpoints, configure these additional environment variables (they can be added under `Values` in `local.settings.json`):
+
+- `TOOLS_SSE_URL`: SSE endpoint of the MCP Function server.  If not set the service will also check `LOCAL_MCP_SSE_URL` or `MCP_SSE_URL`.
+- `TOOLS_FUNCTIONS_KEY`: Optional Functions key used as `x-functions-key`.  Also checked: `LOCAL_MCP_FUNCTIONS_KEY` or `MCP_SSE_KEY`.
+- `ALLOW_CLIENT_MCP_OVERRIDE`: Set to `true` to allow callers to override `mcp_url` and headers per request.
+- `AZURE_OPENAI_MODEL`: Default model to use for `mcp-*` endpoints.
+- `DEFAULT_REASONING_EFFORT`: One of `low`, `medium`, or `high`.
+- `ALLOWED_CORS_ORIGINS`: Comma-separated list of allowed origins for MCP HTTP endpoints.
 - `AZURE_OPENAI_API_VERSION`: Defaults to `2025-01-01-preview`. Ensure your Azure OpenAI resource supports this version.
+- Storage settings: `MCP_JOBS_QUEUE` (default `mcpjobs`) and `MCP_JOBS_CONTAINER` (default `jobs`).
 
-Storage-related (defaults for local development are provided via Azurite):
-- `MCP_JOBS_QUEUE` (default: `mcpjobs`)
-- `MCP_JOBS_CONTAINER` (default: `jobs`)
-
-## Simple Prompting with Ask Function
-### Using Functions CLI
-1) Open a new terminal and do the following:
+### Start the app
 
 ```bash
-pip3 install -r requirements.txt
+pip install -r requirements.txt
 func start
 ```
-2) Using your favorite REST client, e.g. [RestClient in VS Code](https://marketplace.visualstudio.com/items?itemName=humao.rest-client), PostMan, curl, make a post.  [test.http](test.http) has been provided to run this quickly.   
 
-Terminal:
-```bash
-curl -i -X POST http://localhost:7071/api/ask/ \
-  -H "Content-Type: text/json" \
-  --data-binary "@testdata.json"
-```
+See [`test.http`](test.http) for ready-to-run examples.
 
-testdata.json
-```json
-{
-    "prompt": "Write a poem about Azure Functions.  Include two reasons why users love them."
-}
-```
+## Available endpoints
 
-[test.http](test.http)
-```http
-### Simple Ask Completion
-POST http://localhost:7071/api/ask HTTP/1.1
-content-type: application/json
+- `GET /api/ping` – health check.
+- `POST /api/ask` – send a prompt and receive a completion. Supports optional `user_id` and `conversation_id` for memory.
+- MCP endpoints:
+  - `POST /api/mcp-run` – run a prompt with optional tools.
+  - `POST /api/mcp-enqueue` – enqueue a prompt for background processing.
+  - `POST /api/mcp-process` – process a queued job (useful when running locally without a queue trigger).
+  - `GET /api/mcp-result?job_id=<id>` – poll the status or result of a queued job.
+  - `GET /api/mcp-memories` and `GET /api/mcp-memory` – query stored memories.
 
-{
-    "prompt": "Tell me two most popular programming features of Azure Functions"
-}
-
-### Simple Whois Completion
-GET http://localhost:7071/api/whois/Turing HTTP/1.1
-```
-
-## Stateful Interaction with Chatbot using Chat Function
-
-We will use the [test.http](test.http) file again now focusing on the Chat function.  We need to start the chat with `chats` and send messages with `PostChat`.  We can also get state at any time with `GetChatState`.
-
-```http
-### Stateful Chatbot
-### CreateChatBot
-PUT http://localhost:7071/api/chats/abc123
-Content-Type: application/json
-
-{
-    "name": "Sample ChatBot",
-    "description": "This is a sample chatbot."
-}
-
-### PostChat
-POST http://localhost:7071/api/chats/abc123
-Content-Type: application/json
-
-{
-    "message": "Hello, how can I assist you today?"
-}
-
-### PostChat
-POST http://localhost:7071/api/chats/abc123
-Content-Type: application/json
-
-{
-    "message": "Need help with directions from Redmond to SeaTac?"
-}
-
-### GetChatState
-GET http://localhost:7071/api/chats/abc123?timestampUTC=2024-01-15T22:00:00
-Content-Type: application/json
-```
-
-## MCP Tool Orchestration Endpoints
-
-The MCP endpoints are implemented under `mcp/blueprint.py` and registered in the root `function_app.py` using Azure Functions Python v2 Blueprints. They enable direct model calls with MCP tools, and an async queue-based flow to avoid connector 30s timeouts.
-
-### Direct run
-
-POST `/api/mcp-run`
-
-Request body:
-
-```json
-{
-  "prompt": "Hello MCP",
-  "model": "gpt-4o",             
-  "allowed_tools": ["hello_mcp"],
-  "require_approval": "never",
-  "stream": false,
-  "debug": false
-}
-```
-
-Notes:
-- If `ALLOW_CLIENT_MCP_OVERRIDE=true`, you may also pass `mcp_url` and `mcp_headers` to point to a specific MCP server.
-- When `stream=true`, logs of delta tokens are produced server-side; the response still returns the final payload.
-
-### Async pattern
-
-1) POST `/api/mcp-enqueue` with the same body as `mcp-run`. Returns `{ job_id, status: "queued" }`.
-2) GET `/api/mcp-result?job_id=<id>` to poll the status. When running, you may pass `return_partial_output=true` to receive partial output.
-3) Optionally, POST `/api/mcp-process` with `{ job_id }` to force processing if the queue trigger is not firing locally.
-
-The queue trigger streams partial output to blob storage and updates `progress` up to 95 while running; the final result sets `status=done` and `progress=100`.
-
-### Examples via `test.http`
-
-See the new "MCP" section in [`test.http`](test.http) for ready-to-run examples.
+Optional chat endpoints (`PUT|GET|POST /api/chats/{chatId}`) are enabled when the `ENABLE_ASSISTANT_BINDINGS` environment variable is set.
 
 ## Deploy to Azure
 
-The easiest way to deploy this app is using the [Azure Developer CLI](https://aka.ms/azd).  If you open this repo in GitHub CodeSpaces the AZD tooling is already preinstalled.
+Use the [Azure Developer CLI](https://aka.ms/azd) to provision and deploy:
 
-To provision and deploy:
 ```bash
 azd up
 ```
 
-## Source Code
+## License
 
-The key code that makes the prompting and completion work is as follows in [function_app.py](function_app.py).  The `/api/ask` function and route expects a prompt to come in the POST body.  The templating pattern is used to define the input binding for prompt and the underlying parameters for OpenAI models like the maxTokens and the AI model to use for chat.  
-
-The whois function expects a name to be sent in the route `/api/whois/<name>` and you get to see a different example of a route and parameter coming in via http GET.  
-
-### Simple prompting and completions with gpt
-
-```python
-app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
-
-
-# Simple ask http POST function that returns the completion based on prompt
-# This OpenAI completion input requires a {prompt} value in json POST body
-@app.function_name("ask")
-@app.route(route="ask", methods=["POST"])
-@app.text_completion_input(arg_name="response", prompt="{prompt}",
-                           model="%CHAT_MODEL_DEPLOYMENT_NAME%")
-def ask(req: func.HttpRequest, response: str) -> func.HttpResponse:
-    response_json = json.loads(response)
-    return func.HttpResponse(response_json["content"], status_code=200)
-
-
-# Simple WhoIs http GET function that returns the completion based on name
-# This OpenAI completion input requires a {name} binding value.
-@app.function_name("whois")
-@app.route(route="whois/{name}", methods=["GET"])
-@app.text_completion_input(arg_name="response", prompt="Who is {name}?",
-                           max_tokens="100",
-                           model="%CHAT_MODEL_DEPLOYMENT_NAME%")
-def whois(req: func.HttpRequest, response: str) -> func.HttpResponse:
-    response_json = json.loads(response)
-    return func.HttpResponse(response_json["content"], status_code=200)
-```
-
-### Stateful ChatBots with gpt
-
-The stateful chatbot is shown in [function_app.py](function_app.py) routing to `/api/chats`. This is a stateful function meaning you can create or ask for a session by <chatId> and continue where you left off with the same context and memories stored by the function binding (backed Table storage). This makes use of the Assistants feature of the Azure Functions OpenAI extension that has a set of inputs and outputs for this case.
-
-To create or look up a session we have the CreateChatBot as an http PUT function.  Note how the code will reuse your AzureWebJobStorage connection.  The output binding of `assistantCreate` will actually kick off the create.  
-
-```python
-# http PUT function to start ChatBot conversation based on a chatID
-@app.function_name("CreateChatBot")
-@app.route(route="chats/{chatId}", methods=["PUT"])
-@app.assistant_create_output(arg_name="requests")
-def create_chat_bot(req: func.HttpRequest,
-                    requests: func.Out[str]) -> func.HttpResponse:
-    chatId = req.route_params.get("chatId")
-    input_json = req.get_json()
-    logging.info(
-        f"Creating chat ${chatId} from input parameters " +
-        "${json.dumps(input_json)}")
-    create_request = {
-        "id": chatId,
-        "instructions": input_json.get("instructions"),
-        "chatStorageConnectionSetting": CHAT_STORAGE_CONNECTION,
-        "collectionName": COLLECTION_NAME
-    }
-    requests.set(json.dumps(create_request))
-    response_json = {"chatId": chatId}
-    return func.HttpResponse(json.dumps(response_json), status_code=202,
-                             mimetype="application/json")
-```
-
-Subsequent chat messages are sent to the chat as http POST, being careful to use the same chatId. This makes use of the `inputAssistant` input binding to take message as input and do the completion, while also automatically pulling context and memories for the session, and also saving your new state.
-```python
-# http POST function for user to send a message to ChatBot with chatID
-@app.function_name("PostUserResponse")
-@app.route(route="chats/{chatId}", methods=["POST"])
-@app.assistant_post_input(
-    arg_name="state", id="{chatId}",
-    user_message="{message}",
-    model="%CHAT_MODEL_DEPLOYMENT_NAME%",
-    chat_storage_connection_setting=CHAT_STORAGE_CONNECTION,
-    collection_name=COLLECTION_NAME
-    )
-def post_user_response(req: func.HttpRequest, state: str) -> func.HttpResponse:
-    # Parse the JSON string into a dictionary
-    data = json.loads(state)
-
-    # Extract the content of the recentMessage
-    recent_message_content = data['recentMessages'][0]['content']
-    return func.HttpResponse(recent_message_content, status_code=200,
-                             mimetype="text/plain")
-```
-
-MCP endpoints are implemented in [`mcp/blueprint.py`](mcp/blueprint.py) and registered in the root [`function_app.py`](function_app.py). The [`test.http`](test.http) file is helpful to see how clients and APIs should call these functions, and to learn the typical flow.
-
-You can customize this or learn more using [Open AI Triggers and Bindings extension](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-openai?tabs=isolated-process&pivots=programming-language-javascript).  
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- simplify README to describe real endpoints and configuration
- document MCP environment variables and available API routes

## Testing
- `pytest -q`
- `python -m py_compile function_app.py app/blueprint.py`


------
https://chatgpt.com/codex/tasks/task_e_689e02b681ec83289da162d379b4476e