### PR TITLE
Handle init conversation id as new conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [`test.http`](test.http) for ready-to-run examples.
 ## Available endpoints
 
 - `GET /api/ping` – health check.
-- `POST /api/ask` – send a prompt and receive a completion. Supports optional `user_id` and `conversation_id` for memory.
+- `POST /api/ask` – send a prompt and receive a completion. Supports optional `user_id` and `conversation_id` for memory. Use `"init"` as `conversation_id` to start a new conversation.
 - MCP endpoints:
   - `POST /api/mcp-run` – run a prompt with optional tools.
   - `POST /api/mcp-enqueue` – enqueue a prompt for background processing.

--- a/app/blueprint.py
+++ b/app/blueprint.py
@@ -138,6 +138,8 @@ def mcp_run(req: func.HttpRequest) -> func.HttpResponse:
         user_id = (merged.get("user_id") or qp.get("user_id") or "").strip()
         conversation_id = (merged.get("conversation_id") or qp.get("conversation_id"))
         conversation_id = str(conversation_id).strip() if conversation_id else None
+        if conversation_id and conversation_id.lower() == "init":
+            conversation_id = None
         new_conversation = False
         input_messages: Optional[List[dict]] = None
         if user_id:
@@ -423,7 +425,8 @@ def mcp_enqueue(req: func.HttpRequest) -> func.HttpResponse:
         # Enrich job body with canonical conversation id if user_id provided and no conversation_id
         try:
             user_id = str((body.get("user_id") or "").strip()) if isinstance(body, dict) else ""
-            if user_id and not str((body.get("conversation_id") or "").strip()):
+            cid = str((body.get("conversation_id") or "").strip()) if isinstance(body, dict) else ""
+            if user_id and (not cid or cid.lower() == "init"):
                 try:
                     mem_id = cosmos_get_next_memory_id(user_id)
                 except Exception:
@@ -530,6 +533,8 @@ def queue_trigger(msg: func.QueueMessage) -> None:
         mcp_tool_cfg = resolve_mcp_config(body)
         client = create_llm_client()
         conversation_id = str((body.get("conversation_id") or "").strip()) or None
+        if conversation_id and conversation_id.lower() == "init":
+            conversation_id = None
         responses_args: Dict[str, Any] = build_responses_args(
             model, prompt, mcp_tool_cfg, reasoning_effort
         )
@@ -675,6 +680,8 @@ def queue_trigger(msg: func.QueueMessage) -> None:
         try:
             user_id = str((body.get("user_id") or "").strip())
             conversation_id = str((body.get("conversation_id") or "").strip()) or None
+            if conversation_id and conversation_id.lower() == "init":
+                conversation_id = None
             if user_id and conversation_id:
                 cosmos_upsert_conversation_turn(user_id, conversation_id, prompt, output_text)
         except Exception:
@@ -793,6 +800,8 @@ def mcp_process_direct(req: func.HttpRequest) -> func.HttpResponse:
         mcp_tool_cfg = resolve_mcp_config(job_body)
         client = create_llm_client()
         conversation_id = str((job_body.get("conversation_id") or "").strip()) or None
+        if conversation_id and conversation_id.lower() == "init":
+            conversation_id = None
         responses_args: Dict[str, Any] = build_responses_args(model, prompt, mcp_tool_cfg, reasoning_effort)
         # Prefer streaming in direct processing; drop classic tools
         if responses_args.get("tools"):

--- a/function_app.py
+++ b/function_app.py
@@ -159,6 +159,8 @@ def ask(req: func.HttpRequest) -> func.HttpResponse:
         user_id = str(user_id).strip()
         conversation_id = (body.get("conversation_id") if isinstance(body, dict) else None) or qp.get("conversation_id")
         conversation_id = str(conversation_id).strip() if conversation_id else None
+        if conversation_id and conversation_id.lower() == "init":
+            conversation_id = None
         new_conversation = False
         if user_id:
             if not conversation_id:
@@ -452,6 +454,8 @@ def orchestrate(req: func.HttpRequest) -> func.HttpResponse:
         orig_missing_conversation_id = False
         conversation_id = (body.get("conversation_id") if isinstance(body, dict) else None) or qp.get("conversation_id")
         conversation_id = str(conversation_id).strip() if conversation_id else None
+        if conversation_id and conversation_id.lower() == "init":
+            conversation_id = None
         if not conversation_id and user_id:
             # Derive canonical conversation_id as <user_id>_<memory_id>
             try:


### PR DESCRIPTION
## Summary
- Treat `conversation_id: "init"` as a request for a new conversation
- Normalize job payloads that pass `conversation_id: "init"`
- Document the special `init` value for starting new conversations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2690812dc8328901abc8bea9d9716