### PR TITLE
Handle init conversation id

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [`test.http`](test.http) for ready-to-run examples.
 ## Available endpoints
 
 - `GET /api/ping` – health check.
-- `POST /api/ask` – send a prompt and receive a completion. Supports optional `user_id` and `conversation_id` for memory.
+- `POST /api/ask` – send a prompt and receive a completion. Supports optional `user_id` and `conversation_id` for memory. Use `"conversation_id": "init"` to start a new thread explicitly.
 - MCP endpoints:
   - `POST /api/mcp-run` – run a prompt with optional tools.
   - `POST /api/mcp-enqueue` – enqueue a prompt for background processing.

--- a/function_app.py
+++ b/function_app.py
@@ -157,8 +157,10 @@ def ask(req: func.HttpRequest) -> func.HttpResponse:
         # Conversation: only when user_id provided
         user_id = (body.get("user_id") if isinstance(body, dict) else None) or (qp.get("user_id") or "")
         user_id = str(user_id).strip()
-        conversation_id = (body.get("conversation_id") if isinstance(body, dict) else None) or qp.get("conversation_id")
-        conversation_id = str(conversation_id).strip() if conversation_id else None
+        conversation_id_raw = (body.get("conversation_id") if isinstance(body, dict) else None) or qp.get("conversation_id")
+        conversation_id = str(conversation_id_raw).strip() if conversation_id_raw else None
+        if conversation_id and conversation_id.lower() == "init":
+            conversation_id = None
         new_conversation = False
         if user_id:
             if not conversation_id:
@@ -450,8 +452,10 @@ def orchestrate(req: func.HttpRequest) -> func.HttpResponse:
         run_id = str(uuid.uuid4())
         # Normalize conversation_id
         orig_missing_conversation_id = False
-        conversation_id = (body.get("conversation_id") if isinstance(body, dict) else None) or qp.get("conversation_id")
-        conversation_id = str(conversation_id).strip() if conversation_id else None
+        conversation_id_raw = (body.get("conversation_id") if isinstance(body, dict) else None) or qp.get("conversation_id")
+        conversation_id = str(conversation_id_raw).strip() if conversation_id_raw else None
+        if conversation_id and conversation_id.lower() == "init":
+            conversation_id = None
         if not conversation_id and user_id:
             # Derive canonical conversation_id as <user_id>_<memory_id>
             try:


### PR DESCRIPTION
## Summary
- Treat `conversation_id: "init"` as a request to start a new conversation
- Document how to explicitly start a new conversation via `"init"`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a271147bc083288c9935481881a99b