### PR TITLE
Only expose web search tool when backend configured

### DIFF
--- a/app/services/tools.py
+++ b/app/services/tools.py
@@ -143,7 +143,12 @@ def _build_search_web_tool_def() -> Dict[str, Any]:
 
 def get_builtin_tools_config() -> List[Dict[str, Any]]:
     tools: List[Dict[str, Any]] = []
-    tools.append(_build_search_web_tool_def())
+
+    # Only expose web search if backend configuration is present
+    url, key = _websearch_env()
+    if url and key:
+        tools.append(_build_search_web_tool_def())
+
     tools.extend(_build_docsvc_tool_defs())
     return tools
 

--- a/tests/test_tools_config.py
+++ b/tests/test_tools_config.py
@@ -1,0 +1,23 @@
+import os
+from app.services.tools import get_builtin_tools_config
+
+
+def _has_search_web(tools):
+    return any(
+        t.get("name") == "search_web" or t.get("function", {}).get("name") == "search_web"
+        for t in tools
+    )
+
+
+def test_search_web_not_present_when_backend_missing(monkeypatch):
+    monkeypatch.delenv("WEBSEARCH_FUNCTION_URL", raising=False)
+    monkeypatch.delenv("WEBSEARCH_FUNCTION_KEY", raising=False)
+    tools = get_builtin_tools_config()
+    assert not _has_search_web(tools)
+
+
+def test_search_web_present_when_backend_configured(monkeypatch):
+    monkeypatch.setenv("WEBSEARCH_FUNCTION_URL", "https://example.com")
+    monkeypatch.setenv("WEBSEARCH_FUNCTION_KEY", "secret")
+    tools = get_builtin_tools_config()
+    assert _has_search_web(tools)


### PR DESCRIPTION
## Summary
- Guard `search_web` tool definition behind `WEBSEARCH_FUNCTION_URL` and `WEBSEARCH_FUNCTION_KEY`
- Add tests ensuring the web search tool is only available when backend configuration is present

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e90e6d9c8328871d70899c3809c2