### PR TITLE
feat: propagate tool context in conversation tool calls

### DIFF
--- a/app/mcp_worker.py
+++ b/app/mcp_worker.py
@@ -263,7 +263,9 @@ def mcp_process_worker(msg: func.QueueMessage) -> None:
             
             # Create context with user_id for tools
             tool_context = {"user_id": user_id} if user_id else None
-            output_text, response = run_responses_with_tools(client, responses_args, tool_context)
+            output_text, response = run_responses_with_tools(
+                client, responses_args, tool_context=tool_context
+            )
             
             # Log the final output for debugging
             logging.info(f"[mcp-worker] Job {job_id} completed tool execution. Output length: {len(output_text) if output_text else 0}")


### PR DESCRIPTION
## Summary
- allow run_responses_with_tools to accept `tool_context` and forward it to all tool executions
- update worker and tests to pass tool context
- verify context propagation with new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4f5561190832899bf22d6e21737ba