### PR TITLE
Handle tool context for docsvc tools

### DIFF
--- a/app/mcp_worker.py
+++ b/app/mcp_worker.py
@@ -264,7 +264,7 @@ def mcp_process_worker(msg: func.QueueMessage) -> None:
             # Create context with user_id for tools
             tool_context = {"user_id": user_id} if user_id else None
             output_text, response = run_responses_with_tools(
-                client, responses_args, tool_context=tool_context
+                client, responses_args, tool_context, allow_post_synthesis=True
             )
             
             # Log the final output for debugging

--- a/tests/test_docsvc_tool_context.py
+++ b/tests/test_docsvc_tool_context.py
@@ -1,0 +1,30 @@
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from app.services import tools
+
+
+def test_docsvc_tools_use_context_for_user_id(monkeypatch):
+    calls = []
+
+    def fake_request(method, path_template, *, path_params=None, json_body=None, timeout=60):
+        calls.append((method, path_template, path_params))
+        return "ok"
+
+    monkeypatch.setattr(tools, "_docsvc_request", fake_request)
+
+    ctx = {"user_id": "u123"}
+
+    init_result = tools.execute_tool_call("init_user", {}, ctx)
+    images_result = tools.execute_tool_call("list_images", {}, ctx)
+    templates_result = tools.execute_tool_call("list_templates_http", {}, ctx)
+
+    assert init_result == "ok"
+    assert images_result == "ok"
+    assert templates_result == "ok"
+
+    assert calls[0] == ("POST", "/users/{userId}/init", {"userId": "u123"})
+    assert calls[1] == ("GET", "/users/{userId}/images", {"userId": "u123"})
+    assert calls[2] == ("GET", "/users/{userId}/templates", {"userId": "u123"})


### PR DESCRIPTION
## Summary
- pass tool context and enable post-synthesis in MCP worker
- test that doc service tools use user context when user_id arg omitted

## Testing
- `pytest tests/test_docsvc_tool_context.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4f808c7d0832898fa7409c7eeb55a