### PR TITLE
Forward user context to tool orchestration

### DIFF
--- a/app/blueprint.py
+++ b/app/blueprint.py
@@ -341,7 +341,8 @@ def mcp_run(req: func.HttpRequest) -> func.HttpResponse:
         except Exception:
             pass
         if has_classic_tools:
-            output_text, response = run_responses_with_tools(client, responses_args)
+            tool_context = {"user_id": user_id} if user_id else None
+            output_text, response = run_responses_with_tools(client, responses_args, tool_context=tool_context)
             if not output_text:
                 try:
                     no_tools_args = dict(responses_args)
@@ -668,7 +669,8 @@ def queue_trigger(msg: func.QueueMessage) -> None:
             # If classic tools exist, avoid streaming and run tool loop
             # If any classic function tools remain, run tool loop; otherwise, use streaming
             if any((t.get("type") == "function") for t in (responses_args.get("tools") or [])):
-                output_text, _ = run_responses_with_tools(client, responses_args)
+                tool_context = {"user_id": user_id_ctx} if user_id_ctx else None
+                output_text, _ = run_responses_with_tools(client, responses_args, tool_context=tool_context)
                 if not output_text:
                     try:
                         no_tools_args = dict(responses_args)

--- a/function_app.py
+++ b/function_app.py
@@ -229,7 +229,8 @@ def ask(req: func.HttpRequest) -> func.HttpResponse:
             except Exception:
                 pass
             if len(get_builtin_tools_config()) > 0:
-                output_text, response = run_responses_with_tools(client, responses_args)
+                tool_context = {"user_id": user_id} if user_id else None
+                output_text, response = run_responses_with_tools(client, responses_args, tool_context=tool_context)
                 if not output_text:
                     # Fallback: retry without tools to ensure a textual answer
                     try:
@@ -271,7 +272,8 @@ def ask(req: func.HttpRequest) -> func.HttpResponse:
             except Exception:
                 pass
             if len(get_builtin_tools_config()) > 0:
-                output_text, response = run_responses_with_tools(client, responses_args)
+                tool_context = {"user_id": user_id} if user_id else None
+                output_text, response = run_responses_with_tools(client, responses_args, tool_context=tool_context)
                 if not output_text:
                     try:
                         no_tools_args = dict(responses_args)
@@ -636,7 +638,8 @@ def orchestrate(req: func.HttpRequest) -> func.HttpResponse:
                 pass
             # If classic tools exist, use tool loop to allow auto tools in any mode
             if has_classic_tools:
-                output_text, response = run_responses_with_tools(client, responses_args)
+                tool_context = {"user_id": user_id} if user_id else None
+                output_text, response = run_responses_with_tools(client, responses_args, tool_context=tool_context)
                 # Fallback: if no textual output, retry once without tools to ensure an answer
                 if not output_text:
                     try:

--- a/tests_http/mcp-run.http
+++ b/tests_http/mcp-run.http
@@ -108,3 +108,14 @@ Content-Type: application/json
   "stream": true,
   "debug": true
 }
+
+### MCP Run 9 - Hello tool without user_id
+# @name mcp_run_hello_no_user
+POST {{host}}/api/mcp-run
+Content-Type: application/json
+
+{
+  "prompt": "Hi, try testing the `hello_mcp` tool.",
+  "allowed_tools": "hello_mcp",
+  "stream": false
+}

--- a/tests_http/orchestrate.http
+++ b/tests_http/orchestrate.http
@@ -133,3 +133,14 @@ Content-Type: application/json
   "allowed_tools": ["list_templates_http"],
   "user_id": "{{user_id}}"
 }
+
+### Orchestrate 12 - Tools without user_id
+# @name orchestrate12
+POST {{host}}/api/orchestrate
+Content-Type: application/json
+
+{
+  "prompt": "Hi, try testing the `hello_mcp` tool.",
+  "prefer_reasoning": false,
+  "allowed_tools": "hello_mcp"
+}


### PR DESCRIPTION
## Summary
- Pass `user_id` as tool context when invoking `run_responses_with_tools`
- Update synchronous blueprint endpoints to propagate tool context
- Add HTTP scenarios verifying tool execution with `allowed_tools` and no explicit `user_id`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4fa3f8e94832883f565bf49eba747