### PR TITLE
Handle repeated tool calls for classic and MCP tools

### DIFF
--- a/app/blueprint.py
+++ b/app/blueprint.py
@@ -340,7 +340,7 @@ def mcp_run(req: func.HttpRequest) -> func.HttpResponse:
                                         return resp
         except Exception:
             pass
-        if has_classic_tools:
+        if responses_args.get("tools"):
             tool_context = {"user_id": user_id} if user_id else None
             output_text, response = run_responses_with_tools(client, responses_args, tool_context=tool_context)
             if not output_text:
@@ -666,9 +666,8 @@ def queue_trigger(msg: func.QueueMessage) -> None:
         partial_chunks: List[str] = []
         progress_value: int = 1
         try:
-            # If classic tools exist, avoid streaming and run tool loop
-            # If any classic function tools remain, run tool loop; otherwise, use streaming
-            if any((t.get("type") == "function") for t in (responses_args.get("tools") or [])):
+            # If any tools exist, avoid streaming and run tool loop; otherwise, stream
+            if responses_args.get("tools"):
                 tool_context = {"user_id": user_id_ctx} if user_id_ctx else None
                 output_text, _ = run_responses_with_tools(client, responses_args, tool_context=tool_context)
                 if not output_text:

--- a/app/mcp_worker.py
+++ b/app/mcp_worker.py
@@ -206,10 +206,11 @@ def mcp_process_worker(msg: func.QueueMessage) -> None:
         except Exception:
             pass
 
-        # Check for classic function tools and reasoning effort
+        # Check for tool availability
         has_classic_tools = any(
             (t.get("type") == "function") for t in (responses_args.get("tools") or [])
         )
+        has_tools = bool(responses_args.get("tools"))
         
         # Determine if this is a reasoning task (deep thinking)
         is_reasoning_task = reasoning_effort in ("medium", "high") or any(
@@ -248,8 +249,8 @@ def mcp_process_worker(msg: func.QueueMessage) -> None:
         output_text: Optional[str] = None
         tools_used_during_run: List[str] = []
 
-        if has_classic_tools:
-            # Use synchronous tool loop for classic function tools
+        if has_tools:
+            # Use synchronous tool loop for any tools
             _update_job_status(job_id, "running", 20, "Processing with tools...", created_at=created_at)
             
             # Force explicit tool selection for tool usage

--- a/function_app.py
+++ b/function_app.py
@@ -228,7 +228,7 @@ def ask(req: func.HttpRequest) -> func.HttpResponse:
                     responses_args["x_user_id"] = user_id
             except Exception:
                 pass
-            if len(get_builtin_tools_config()) > 0:
+            if responses_args.get("tools"):
                 tool_context = {"user_id": user_id} if user_id else None
                 output_text, response = run_responses_with_tools(client, responses_args, tool_context=tool_context)
                 if not output_text:
@@ -271,7 +271,7 @@ def ask(req: func.HttpRequest) -> func.HttpResponse:
                     responses_args["x_user_id"] = user_id
             except Exception:
                 pass
-            if len(get_builtin_tools_config()) > 0:
+            if responses_args.get("tools"):
                 tool_context = {"user_id": user_id} if user_id else None
                 output_text, response = run_responses_with_tools(client, responses_args, tool_context=tool_context)
                 if not output_text:
@@ -636,8 +636,8 @@ def orchestrate(req: func.HttpRequest) -> func.HttpResponse:
                                     return resp
             except Exception:
                 pass
-            # If classic tools exist, use tool loop to allow auto tools in any mode
-            if has_classic_tools:
+            # If any tools are configured, use tool loop to allow repeated tool calls
+            if responses_args.get("tools"):
                 tool_context = {"user_id": user_id} if user_id else None
                 output_text, response = run_responses_with_tools(client, responses_args, tool_context=tool_context)
                 # Fallback: if no textual output, retry once without tools to ensure an answer


### PR DESCRIPTION
## Summary
- Run `run_responses_with_tools` whenever any tools are attached so models can loop through classic or MCP tools repeatedly.
- Apply unified tool-loop logic across Function App, HTTP blueprint, and MCP worker.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pytest tests/test_conversation_tools.py tests/test_docsvc_tool_context.py tests/test_memory_sanitization.py tests/test_tools_config.py tests/test_invalid_unicode_escapes.py tests/test_degree_symbol_removal.py tests/test_forced_single_tool_fallback.py tests/test_inline_tool_blocks.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a50ff41a448328ad9f3eeaabb3cd49