### PR TITLE
Remove deprecated mcp-result references

### DIFF
--- a/Connecteur PowerApps/swagger_power_apps.json
+++ b/Connecteur PowerApps/swagger_power_apps.json
@@ -406,42 +406,6 @@
                 }
             }
         },
-        "/api/mcp-result": {
-            "get": {
-                "summary": "Get the status/result of a queued job",
-                "operationId": "McpResult",
-                "parameters": [
-                    {
-                        "name": "job_id",
-                        "in": "query",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "return_partial_output",
-                        "in": "query",
-                        "required": false,
-                        "type": "boolean"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Job status/result",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "404": {
-                        "description": "Not found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
         "/api/mcp-memories": {
             "get": {
                 "summary": "List stored memories for a user",

--- a/Connecteur PowerApps/swagger_power_apps.yaml
+++ b/Connecteur PowerApps/swagger_power_apps.yaml
@@ -231,30 +231,6 @@ paths:
           description: Missing job_id
         "404":
           description: Unknown job
-  /api/mcp-result:
-    get:
-      summary: Get the status/result of a queued job
-      operationId: McpResult
-      parameters:
-        - name: job_id
-          in: query
-          required: true
-          type: string
-        - name: return_partial_output
-          in: query
-          required: false
-          type: boolean
-      responses:
-        "200":
-          description: Job status/result
-          schema:
-            type: object
-            additionalProperties: true
-        "404":
-          description: Not found
-          schema:
-            type: object
-            additionalProperties: true
   /api/mcp-memories:
     get:
       summary: List stored memories for a user

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Le projet offre **6 modes d'utilisation** distincts :
 - Compatible **Copilot Studio** (< 30s response + polling)
 - Messages contextuels : "Analyse et sélection du modèle…", "Réflexion approfondie…"
 
-**7. `POST /api/mcp-enqueue` + `GET /api/mcp-result`** - MCP Streaming
+**7. `POST /api/mcp-run`** - MCP Streaming
 - Outils MCP en streaming
 - Progress détaillé pendant l'exécution des tools
 - Messages spécialisés selon l'outil utilisé
@@ -182,7 +182,6 @@ See [`test.http`](test.http) for ready-to-run examples.
   - `POST /api/mcp-run` – run a prompt with optional tools.
   - `POST /api/mcp-enqueue` – enqueue a prompt for background processing.
   - `POST /api/mcp-process` – process a queued job (useful when running locally without a queue trigger).
-  - `GET /api/mcp-result?job_id=<id>` – poll the status or result of a queued job.
   - `GET /api/mcp-memories` and `GET /api/mcp-memory` – query stored memories.
 
 Optional chat endpoints (`PUT|GET|POST /api/chats/{chatId}`) are enabled when the `ENABLE_ASSISTANT_BINDINGS` environment variable is set.

--- a/tests_http/mcp-queue.http
+++ b/tests_http/mcp-queue.http
@@ -17,12 +17,20 @@ Content-Type: application/json
   "allowed_tools": "*"
 }
 
-### MCP Result - Poll job status/result (manual job ID)
-# @name mcp_result
-GET {{host}}/api/mcp-result?job_id={{job_id}}&return_partial_output=true
-Accept: application/json
+### MCP Process - Process queued job (manual job ID)
+# @name mcp_process
+POST {{host}}/api/mcp-process
+Content-Type: application/json
 
-### MCP Result - Poll job status/result (auto job ID from enqueue)
-# @name mcp_result_auto
-GET {{host}}/api/mcp-result?job_id={{mcp_enqueue.response.body.job_id}}&return_partial_output=true
-Accept: application/json
+{
+  "job_id": "{{job_id}}"
+}
+
+### MCP Process - Process queued job (auto job ID from enqueue)
+# @name mcp_process_auto
+POST {{host}}/api/mcp-process
+Content-Type: application/json
+
+{
+  "job_id": "{{mcp_enqueue.response.body.job_id}}"
+}


### PR DESCRIPTION
## Summary
- remove mcp-result endpoint references in docs and connector specs
- update PowerApps HTTP examples to process queued jobs via `mcp-process`
- clean README endpoint list to reflect `mcp-run` workflow

## Testing
- `pytest`
- `python - <<'PY' ...` (failed: ModuleNotFoundError: No module named 'yaml')
- `pip install pyyaml` (failed: Could not find a version that satisfies the requirement pyyaml)


------
https://chatgpt.com/codex/tasks/task_e_68a5f764815083288003a2993ec28db7