### PR TITLE
refactor: centralize routing helpers

### DIFF
--- a/app/blueprint.py
+++ b/app/blueprint.py
@@ -11,6 +11,7 @@ from azure.storage.queue import QueueClient
 from azure.storage.blob import BlobServiceClient
 
 from .services.tools import resolve_mcp_config, normalize_allowed_tools
+from .services.routing import _orchestrator_models, _route_mode
 
 from .services.tools import execute_tool_call
 from .services.conversation import (
@@ -80,47 +81,6 @@ def _preflight_response(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse(status_code=204, headers=headers)
 
 
-def _orchestrator_models() -> dict:
-    return {
-        "trivial": os.getenv("ORCHESTRATOR_MODEL_TRIVIAL"),
-        "standard": os.getenv("ORCHESTRATOR_MODEL_STANDARD"),
-        "tools": os.getenv("ORCHESTRATOR_MODEL_TOOLS"),
-        "deep": os.getenv("ORCHESTRATOR_MODEL_REASONING"),
-    }
-
-
-def _route_mode(prompt: str, has_tools: bool, constraints: dict, allowed_tools: Optional[List[str]] = None) -> str:
-    # Only select tools mode if caller explicitly allows tools
-    if has_tools and allowed_tools:
-        return "tools"
-    # Accept both camelCase and snake_case flags and flat boolean values
-    prefer_reasoning = False
-    try:
-        prefer_reasoning = str(constraints.get("preferReasoning", "")).lower() in ("1", "true", "yes", "on") or \
-                           str(constraints.get("prefer_reasoning", "")).lower() in ("1", "true", "yes", "on")
-    except Exception:
-        prefer_reasoning = False
-    try:
-        max_latency_ms = int(constraints.get("maxLatencyMs")) if constraints.get("maxLatencyMs") is not None else None
-    except Exception:
-        max_latency_ms = None
-    text = (prompt or "").lower()
-    # Include French markers so FR prompts can trigger reasoning automatically
-    deep_markers = (
-        "plan", "multi-step", "derive", "prove", "why", "strategy", "chain of thought",
-        "plan d'action", "multi-etapes", "multi étapes", "démontrer", "demontrer", "prouve", "pourquoi",
-        "stratégie", "strategie", "raisonnement", "chaine de raisonnement", "chaîne de raisonnement",
-        "réfléchis", "reflechis", "pas à pas", "pas a pas", "analyse détaillée", "explication détaillée"
-    )
-    if prefer_reasoning or any(m in text for m in deep_markers) or len(prompt) > 800:
-        # If explicit latency budget is tight, downshift to standard
-        if max_latency_ms is not None and max_latency_ms < 1500:
-            return "standard"
-        return "deep"
-    # length-based quick rule
-    if len(prompt) < 160:
-        return "trivial"
-    return "standard"
 
 
 def _apply_cors(resp: func.HttpResponse, req: func.HttpRequest) -> func.HttpResponse:

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     "storage",
     "memory",
     "tools",
+    "routing",
 ]
 
 

--- a/app/services/routing.py
+++ b/app/services/routing.py
@@ -1,0 +1,78 @@
+import os
+from typing import List, Optional
+
+
+def _orchestrator_models() -> dict:
+    return {
+        "trivial": os.getenv("ORCHESTRATOR_MODEL_TRIVIAL"),
+        "standard": os.getenv("ORCHESTRATOR_MODEL_STANDARD"),
+        "tools": os.getenv("ORCHESTRATOR_MODEL_TOOLS"),
+        "deep": os.getenv("ORCHESTRATOR_MODEL_REASONING"),
+    }
+
+
+def _route_mode(
+    prompt: str,
+    has_tools: bool,
+    constraints: dict,
+    allowed_tools: Optional[List[str]] = None,
+) -> str:
+    # Only select tools mode if caller explicitly allows tools
+    if has_tools and allowed_tools:
+        return "tools"
+    # Accept both camelCase and snake_case flags and flat boolean values
+    prefer_reasoning = False
+    try:
+        prefer_reasoning = (
+            str(constraints.get("preferReasoning", "")).lower() in ("1", "true", "yes", "on")
+            or str(constraints.get("prefer_reasoning", "")).lower() in ("1", "true", "yes", "on")
+        )
+    except Exception:
+        prefer_reasoning = False
+    try:
+        max_latency_ms = (
+            int(constraints.get("maxLatencyMs"))
+            if constraints.get("maxLatencyMs") is not None
+            else None
+        )
+    except Exception:
+        max_latency_ms = None
+    text = (prompt or "").lower()
+    # Include French markers so FR prompts can trigger reasoning automatically
+    deep_markers = (
+        "plan",
+        "multi-step",
+        "derive",
+        "prove",
+        "why",
+        "strategy",
+        "chain of thought",
+        "plan d'action",
+        "multi-etapes",
+        "multi étapes",
+        "démontrer",
+        "demontrer",
+        "prouve",
+        "pourquoi",
+        "stratégie",
+        "strategie",
+        "raisonnement",
+        "chaine de raisonnement",
+        "chaîne de raisonnement",
+        "réfléchis",
+        "reflechis",
+        "pas à pas",
+        "pas a pas",
+        "analyse détaillée",
+        "explication détaillée",
+    )
+    if prefer_reasoning or any(m in text for m in deep_markers) or len(prompt) > 800:
+        # If explicit latency budget is tight, downshift to standard
+        if max_latency_ms is not None and max_latency_ms < 1500:
+            return "standard"
+        return "deep"
+    # length-based quick rule
+    if len(prompt) < 160:
+        return "trivial"
+    return "standard"
+

--- a/function_app.py
+++ b/function_app.py
@@ -14,6 +14,7 @@ from app.services.memory import get_conversation_messages as cosmos_get_conversa
 from app.services.memory import upsert_conversation_turn as cosmos_upsert_conversation_turn
 from app.services.memory import get_next_memory_id as cosmos_get_next_memory_id
 from app.services.tools import resolve_mcp_config
+from app.services.routing import _orchestrator_models, _route_mode
 from app.services.conversation import (
     build_responses_args,
     run_responses_with_tools,
@@ -423,51 +424,6 @@ def ask(req: func.HttpRequest) -> func.HttpResponse:
         return func.HttpResponse(json.dumps({"error": str(e)}, ensure_ascii=False), status_code=500, mimetype="application/json")
 
 
-def _orchestrator_models() -> dict:
-    return {
-        "trivial": (
-            os.getenv("ORCHESTRATOR_MODEL_TRIVIAL")),
-        "standard": (
-            os.getenv("ORCHESTRATOR_MODEL_STANDARD")),
-        "tools": (
-            os.getenv("ORCHESTRATOR_MODEL_TOOLS")),
-        "deep": (
-            os.getenv("ORCHESTRATOR_MODEL_REASONING")),
-    }
-
-
-def _route_mode(prompt: str, has_tools: bool, constraints: dict, allowed_tools: Optional[list] = None) -> str:
-    # Only select tools mode if caller explicitly allows tools
-    if has_tools and allowed_tools:
-        return "tools"
-    # Accept both camelCase and snake_case flags and flat boolean values
-    prefer_reasoning = False
-    try:
-        prefer_reasoning = str(constraints.get("preferReasoning", "")).lower() in ("1", "true", "yes", "on") or \
-                           str(constraints.get("prefer_reasoning", "")).lower() in ("1", "true", "yes", "on")
-    except Exception:
-        prefer_reasoning = False
-    try:
-        max_latency_ms = int(constraints.get("maxLatencyMs")) if constraints.get("maxLatencyMs") is not None else None
-    except Exception:
-        max_latency_ms = None
-    text = (prompt or "").lower()
-    # Include French markers so FR prompts can trigger reasoning automatically
-    deep_markers = (
-        "plan", "multi-step", "derive", "prove", "why", "strategy", "chain of thought",
-        "plan d'action", "multi-etapes", "multi étapes", "démontrer", "demontrer", "prouve", "pourquoi",
-        "stratégie", "strategie", "raisonnement", "chaine de raisonnement", "chaîne de raisonnement",
-        "réfléchis", "reflechis", "pas à pas", "pas a pas", "analyse détaillée", "explication détaillée"
-    )
-    if prefer_reasoning or any(m in text for m in deep_markers) or len(prompt) > 800:
-        # If explicit latency budget is tight, downshift to standard
-        if max_latency_ms is not None and max_latency_ms < 1500:
-            return "standard"
-        return "deep"
-    # length-based quick rule
-    if len(prompt) < 160:
-        return "trivial"
-    return "standard"
 
 
 # Orchestrate endpoint: choose model/reasoning, optionally execute


### PR DESCRIPTION
## Summary
- move mode selection and model mapping logic into shared `app/services/routing.py`
- reuse routing helpers in `app/blueprint.py` and `function_app.py`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5fa9365ec8328aa2b520462858e62