### PR TITLE
refactor: use shared storage helper

### DIFF
--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -6,7 +6,7 @@ from azure.storage.queue import QueueClient
 from azure.storage.blob import BlobServiceClient
 
 
-def get_storage_clients() -> Dict[str, Any]:
+def get_storage_clients(queue_name: str = "mcpjobs") -> Dict[str, Any]:
     conn_str = os.getenv("AzureWebJobsStorage")
     if conn_str and conn_str.strip().lower().startswith("usedevelopmentstorage=true"):
         conn_str = (
@@ -18,11 +18,11 @@ def get_storage_clients() -> Dict[str, Any]:
         )
     if not conn_str:
         raise RuntimeError("Missing AzureWebJobsStorage connection string.")
-    queue_name = "mcpjobs"
+    container = os.getenv("MCP_JOBS_CONTAINER", "jobs")
     return {
         "queue": QueueClient.from_connection_string(conn_str, queue_name=queue_name),
         "blob": BlobServiceClient.from_connection_string(conn_str),
-        "container": "jobs",
+        "container": container,
     }
 
 


### PR DESCRIPTION
## Summary
- remove private storage helper in blueprint
- use shared storage helper for all endpoints
- expose queue and container options in storage helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5fbdf74648328bad0a8f49f67929f