### PR TITLE
refactor: centralize storage client

### DIFF
--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -6,7 +6,14 @@ from azure.storage.queue import QueueClient
 from azure.storage.blob import BlobServiceClient
 
 
-def get_storage_clients() -> Dict[str, Any]:
+def get_storage_clients(queue_name: str = "mcpjobs") -> Dict[str, Any]:
+    """Return initialized storage clients.
+
+    Parameters
+    ----------
+    queue_name: str
+        Name of the queue to connect to. Defaults to ``"mcpjobs"``.
+    """
     conn_str = os.getenv("AzureWebJobsStorage")
     if conn_str and conn_str.strip().lower().startswith("usedevelopmentstorage=true"):
         conn_str = (
@@ -18,11 +25,10 @@ def get_storage_clients() -> Dict[str, Any]:
         )
     if not conn_str:
         raise RuntimeError("Missing AzureWebJobsStorage connection string.")
-    queue_name = "mcpjobs"
     return {
         "queue": QueueClient.from_connection_string(conn_str, queue_name=queue_name),
         "blob": BlobServiceClient.from_connection_string(conn_str),
-        "container": "jobs",
+        "container": os.getenv("MCP_JOBS_CONTAINER", "jobs"),
     }
 
 


### PR DESCRIPTION
## Summary
- remove private storage client helper from blueprint
- use shared services.storage.get_storage_clients with optional queue name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a606edf5cc832887dfdc1c19fc16df