### PR TITLE
refactor: rely on Retry-After for ask status polling

### DIFF
--- a/app/blueprint.py
+++ b/app/blueprint.py
@@ -821,9 +821,8 @@ def ask_status(req: func.HttpRequest) -> func.HttpResponse:
             if content.get("mode") == "ask":
                 message = content.get("message", "Réflexion en cours…")
         
-        # Add 5 second delay for status polling to limit API calls
-        if mapped_status in ("queued", "running", "tool"):
-            time.sleep(5)
+        # Clients may poll rapidly; rely on Retry-After header instead of server-side sleeps
+        # to advise on backoff intervals.
 
         # Try to get conversation_id from request blob
         conversation_id = ""


### PR DESCRIPTION
## Summary
- remove server-side delay from `ask_status`
- instruct clients to respect `Retry-After` header for polling intervals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60869e1188328b995f05132a0d8cc