### PR TITLE
docs: remove mcp-result references

### DIFF
--- a/Connecteur PowerApps/swagger_power_apps.json
+++ b/Connecteur PowerApps/swagger_power_apps.json
@@ -406,42 +406,6 @@
                 }
             }
         },
-        "/api/mcp-result": {
-            "get": {
-                "summary": "Get the status/result of a queued job",
-                "operationId": "McpResult",
-                "parameters": [
-                    {
-                        "name": "job_id",
-                        "in": "query",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "return_partial_output",
-                        "in": "query",
-                        "required": false,
-                        "type": "boolean"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Job status/result",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "404": {
-                        "description": "Not found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
         "/api/mcp-memories": {
             "get": {
                 "summary": "List stored memories for a user",

--- a/Connecteur PowerApps/swagger_power_apps.yaml
+++ b/Connecteur PowerApps/swagger_power_apps.yaml
@@ -231,30 +231,6 @@ paths:
           description: Missing job_id
         "404":
           description: Unknown job
-  /api/mcp-result:
-    get:
-      summary: Get the status/result of a queued job
-      operationId: McpResult
-      parameters:
-        - name: job_id
-          in: query
-          required: true
-          type: string
-        - name: return_partial_output
-          in: query
-          required: false
-          type: boolean
-      responses:
-        "200":
-          description: Job status/result
-          schema:
-            type: object
-            additionalProperties: true
-        "404":
-          description: Not found
-          schema:
-            type: object
-            additionalProperties: true
   /api/mcp-memories:
     get:
       summary: List stored memories for a user

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Le projet offre **6 modes d'utilisation** distincts :
 - Compatible **Copilot Studio** (< 30s response + polling)
 - Messages contextuels : "Analyse et sélection du modèle…", "Réflexion approfondie…"
 
-**7. `POST /api/mcp-enqueue` + `GET /api/mcp-result`** - MCP Streaming
-- Outils MCP en streaming
-- Progress détaillé pendant l'exécution des tools
-- Messages spécialisés selon l'outil utilisé
+**7. `POST /api/mcp-enqueue` + `POST /api/mcp-process`** - MCP Streaming
+ - Outils MCP en streaming
+ - Progress détaillé pendant l'exécution des tools
+ - Messages spécialisés selon l'outil utilisé
 
 ### 🧠 **Gestion Mémoire Conversations**
 
@@ -181,8 +181,7 @@ See [`test.http`](test.http) for ready-to-run examples.
 - MCP endpoints:
   - `POST /api/mcp-run` – run a prompt with optional tools.
   - `POST /api/mcp-enqueue` – enqueue a prompt for background processing.
-  - `POST /api/mcp-process` – process a queued job (useful when running locally without a queue trigger).
-  - `GET /api/mcp-result?job_id=<id>` – poll the status or result of a queued job.
+  - `POST /api/mcp-process` – process a queued job and return its result (useful when running locally without a queue trigger).
   - `GET /api/mcp-memories` and `GET /api/mcp-memory` – query stored memories.
 
 Optional chat endpoints (`PUT|GET|POST /api/chats/{chatId}`) are enabled when the `ENABLE_ASSISTANT_BINDINGS` environment variable is set.

--- a/images/mcp_orchestrations.drawio
+++ b/images/mcp_orchestrations.drawio
@@ -218,7 +218,7 @@
                 <mxCell id="11" value="Write final result {status: done, output_text, progress: 100, duration_ms} → Blob {job_id}.json" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;" parent="1" vertex="1">
                     <mxGeometry x="2600" y="200" width="540" height="70" as="geometry"/>
                 </mxCell>
-                <mxCell id="12" value="Azure Function /api/mcp-result?job_id=… (client polls)" style="rounded=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                <mxCell id="12" value="Azure Function /api/mcp-process (client processes job)" style="rounded=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
                     <mxGeometry x="660" y="340" width="420" height="60" as="geometry"/>
                 </mxCell>
                 <mxCell id="13" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;" parent="1" source="2" target="3" edge="1">

--- a/tests_http/mcp-queue.http
+++ b/tests_http/mcp-queue.http
@@ -17,12 +17,20 @@ Content-Type: application/json
   "allowed_tools": "*"
 }
 
-### MCP Result - Poll job status/result (manual job ID)
-# @name mcp_result
-GET {{host}}/api/mcp-result?job_id={{job_id}}&return_partial_output=true
-Accept: application/json
+### MCP Process - Process job (manual job ID)
+# @name mcp_process
+POST {{host}}/api/mcp-process
+Content-Type: application/json
 
-### MCP Result - Poll job status/result (auto job ID from enqueue)
-# @name mcp_result_auto
-GET {{host}}/api/mcp-result?job_id={{mcp_enqueue.response.body.job_id}}&return_partial_output=true
-Accept: application/json
+{
+  "job_id": "{{job_id}}"
+}
+
+### MCP Process - Process job (auto job ID from enqueue)
+# @name mcp_process_auto
+POST {{host}}/api/mcp-process
+Content-Type: application/json
+
+{
+  "job_id": "{{mcp_enqueue.response.body.job_id}}"
+}

--- a/tests_http/test.http
+++ b/tests_http/test.http
@@ -421,11 +421,6 @@ Content-Type: application/json
   "job_id": "{{job_id}}"
 }
 
-### MCP Result (poll job status/result)
-# @name mcp_result
-GET {{host}}/api/mcp-result?job_id={{job_id}}&return_partial_output=true
-Accept: application/json
-
 
 
 

--- a/todo.md
+++ b/todo.md
@@ -564,7 +564,6 @@ mcp_run: [POST] http://localhost:7071/api/mcp-run
 Permet seulement l'utilisation des tools MCP sans streaming
 
 mcp_process: [POST,OPTIONS] http://localhost:7071/api/mcp-process
-mcp_result: [GET,OPTIONS] http://localhost:7071/api/mcp-result
 
 meme que mcp-run avec streaming
 


### PR DESCRIPTION
## Summary
- replace old mcp-result references with mcp-process
- update swagger specs and HTTP examples
- refresh orchestration diagram for new endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a60d97adf88328b3ec0d0eb16dc508