### PR TITLE
Add MCP run and process endpoints

### DIFF
--- a/tests_http/mcp-queue.http
+++ b/tests_http/mcp-queue.http
@@ -34,3 +34,14 @@ Content-Type: application/json
 {
   "job_id": "{{mcp_enqueue.response.body.job_id}}"
 }
+
+### MCP Process - Direct prompt streaming
+# @name mcp_process_direct_run
+POST {{host}}/api/mcp-process
+Content-Type: application/json
+
+{
+  "prompt": "Stream a short acknowledgement.",
+  "stream": true,
+  "allowed_tools": "*"
+}

--- a/tests_http/mcp-run.http
+++ b/tests_http/mcp-run.http
@@ -119,3 +119,13 @@ Content-Type: application/json
   "allowed_tools": "hello_mcp",
   "stream": false
 }
+
+### MCP Run 10 - Simple greeting
+# @name mcp_run_basic_simple
+POST {{host}}/api/mcp-run
+Content-Type: application/json
+
+{
+  "prompt": "Say hello from mcp run.",
+  "stream": false
+}


### PR DESCRIPTION
## Summary
- add synchronous `/api/mcp-run` endpoint
- add `/api/mcp-process` endpoint capable of processing queued jobs or direct prompts
- extend http tests for new MCP endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a63b2b1b2c832898cf6127d03bb066