### PR TITLE
Use real websearch backend in websearch_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Le projet offre **6 modes d'utilisation** distincts :
 - Pas compatible Copilot Studio (pas de streaming)
 - Usage avancé pour intégrations spécifiques
 
-**4. `POST /api/websearch-test`** - Test simple `search_web`
+**4. `POST /api/websearch-test`** - Test simple `search_web` (nécessite `WEBSEARCH_FUNCTION_URL` et éventuellement `WEBSEARCH_FUNCTION_KEY`)
 - Exemple minimal d'appel avec l'outil `search_web` utilisé automatiquement
 
 ### ⚡ **Endpoints Asynchrones Streaming (Job + Polling)**


### PR DESCRIPTION
## Summary
- Replace fake websearch result with real HTTP call in `websearch_test`
- Document websearch backend environment variables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a63d940ed4832887ec87c8137b74a1