### PR TITLE
test: add word_create_document mcp tool test

### DIFF
--- a/tests_http/mcp_word_tools.http
+++ b/tests_http/mcp_word_tools.http
@@ -112,6 +112,20 @@ Content-Type: application/json
   "args": { "user_id": "{{user_id}}" }
 }
 
+### word_create_document
+# @name word_create_document
+POST {{host}}/api/mcp-tool-test
+Content-Type: application/json
+
+{
+  "tool": "word_create_document",
+  "prompt": "Invoke word_create_document.",
+  "args": {
+    "user_id": "{{user_id}}",
+    "filename": "mcp_test.docx"
+  }
+}
+
 ### word_delete_paragraph
 # @name word_delete_paragraph
 POST {{host}}/api/mcp-tool-test


### PR DESCRIPTION
## Summary
- test word_create_document through MCP `/api/mcp-tool-test` endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a640d12be083288896dfc42714ee1c