### PR TITLE
Ensure tools config test imports builtin config

### DIFF
--- a/tests/test_tools_config.py
+++ b/tests/test_tools_config.py
@@ -1,4 +1,3 @@
-import os
 from app.services.tools import get_builtin_tools_config
 
 


### PR DESCRIPTION
## Summary
- import `get_builtin_tools_config` from the tools service directly in the tools-config test

## Testing
- `PYTHONPATH=. pytest tests/test_tools_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a645aef8248328ba5b7bb132b02e30