### PR TITLE
Add route_mode unit tests

### DIFF
--- a/tests/test_route_mode.py
+++ b/tests/test_route_mode.py
@@ -1,0 +1,40 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from app.services.conversation import route_mode
+
+
+def test_trivial_mode_for_short_prompt():
+    mode = route_mode("Hi", has_tools=False, constraints={})
+    assert mode == "trivial"
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "Can you plan a trip for me?",
+        "Explique pourquoi le ciel est bleu.",
+    ],
+)
+def test_deep_mode_with_markers(prompt):
+    mode = route_mode(prompt, has_tools=False, constraints={})
+    assert mode == "deep"
+
+
+def test_standard_mode_with_markers_and_latency():
+    prompt = "Explique pourquoi le ciel est bleu."
+    mode = route_mode(prompt, has_tools=False, constraints={"maxLatencyMs": 1000})
+    assert mode == "standard"
+
+
+def test_tools_mode_when_tools_allowed():
+    mode = route_mode(
+        "Use tools please",
+        has_tools=True,
+        constraints={},
+        allowed_tools=["search"],
+    )
+    assert mode == "tools"


### PR DESCRIPTION
## Summary
- add tests covering route_mode behavior for short prompts, reasoning markers, latency constraints and tools mode

## Testing
- `pytest tests/test_route_mode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a646926abc83288684881021a553a0