### PR TITLE
Add tests for normalize_allowed_tools

### DIFF
--- a/tests/test_normalize_allowed_tools.py
+++ b/tests/test_normalize_allowed_tools.py
@@ -1,0 +1,20 @@
+import pytest
+
+from app.services.tools import normalize_allowed_tools
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (["a", "b"], ["a", "b"]),
+        ("a, b", ["a", "b"]),
+        ('["a", 1]', ["a", "1"]),
+    ],
+)
+def test_normalize_allowed_tools_valid_inputs(raw, expected):
+    assert normalize_allowed_tools(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [None, "", {}, 123, "[invalid]"])
+def test_normalize_allowed_tools_invalid_inputs(raw):
+    assert normalize_allowed_tools(raw) is None


### PR DESCRIPTION
## Summary
- add unit tests for normalize_allowed_tools covering list, CSV, JSON, and invalid inputs

## Testing
- `PYTHONPATH=. pytest tests/test_normalize_allowed_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a647ad7d7083289eda8cc474d4b985